### PR TITLE
fix: prevent state.json race condition

### DIFF
--- a/.github/workflows/notify.yml
+++ b/.github/workflows/notify.yml
@@ -14,6 +14,10 @@ on:
   schedule:
     - cron: "20 * * * *" # Backup: run after ETL job in case workflow_run fails
 
+concurrency:
+  group: vulnradar-notify
+  cancel-in-progress: false
+
 permissions:
   contents: write
   issues: write
@@ -82,7 +86,7 @@ jobs:
             echo "No state changes to commit"
           else
             git commit -m "Update notification state [skip ci]"
-            git pull --rebase
+            git pull --rebase -X theirs
             git push
             echo "State file committed"
           fi


### PR DESCRIPTION
## Summary
- Add `concurrency` group (`vulnradar-notify`, `cancel-in-progress: false`) to serialize notification runs
- Use `git pull --rebase -X theirs` to auto-resolve state.json conflicts from concurrent runs

This is the same fix as RogoLabs/VulnRadar-Demo#118, applied to the parent repo so it flows downstream on sync.

## Test plan
- [ ] Verify notify workflow runs serialize (no concurrent execution)
- [ ] Confirm state.json commits don't conflict when ETL + scheduled triggers overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)