### PR TITLE
fix: apply min_cvss threshold to filter radar data

### DIFF
--- a/vulnradar/cli.py
+++ b/vulnradar/cli.py
@@ -267,6 +267,7 @@ def main_etl(argv: Sequence[str] | None = None) -> int:
             include_kev_outside_window=bool(args.include_kev_outside_window),
             severity_threshold=wl.thresholds.severity_threshold,
             epss_threshold=wl.thresholds.epss_threshold,
+            min_cvss=wl.thresholds.min_cvss,
         )
     finally:
         shutil.rmtree(extracted, ignore_errors=True)

--- a/vulnradar/enrichment.py
+++ b/vulnradar/enrichment.py
@@ -132,6 +132,7 @@ def build_radar_data(
     include_kev_outside_window: bool,
     severity_threshold: float | None = None,
     epss_threshold: float | None = None,
+    min_cvss: float = 0.0,
 ) -> list[dict[str, Any]]:
     """Assemble the final radar dataset.
 
@@ -154,6 +155,8 @@ def build_radar_data(
             this score AND on the watchlist are flagged critical.
         epss_threshold: Optional EPSS floor — CVEs at or above this
             probability AND on the watchlist are flagged critical.
+        min_cvss: Minimum CVSS score to include. CVEs below this
+            threshold are excluded unless they are active threats (KEV).
 
     Returns:
         List of enriched radar item dicts.
@@ -289,6 +292,11 @@ def build_radar_data(
                 "cpe_count": nvd.get("cpe_count"),
                 "reference_count": nvd.get("reference_count"),
             }
+
+        if min_cvss > 0 and not active_threat:
+            cvss = record.get("cvss_score")
+            if cvss is None or cvss < min_cvss:
+                continue
 
         items.append(record)
 


### PR DESCRIPTION
## Summary
- `min_cvss` from `watchlist.yaml` thresholds was parsed but never passed to `build_radar_data()`, so all watchlist-matching CVEs were included regardless of CVSS score
- This caused `radar_data.json` to exceed GitHub's 100MB file size limit on VulnRadar-Demo (which uses `min_cvss: 7.0`)
- Now CVEs below the threshold are excluded, with KEV (active threat) entries always passing through

## Test plan
- [x] All 331 existing tests pass
- [ ] After merge, run `reset_demo.sh` on VulnRadar-Demo and verify `radar_data.json` stays under 100MB
- [ ] Verify KEV entries with low CVSS scores are still included

🤖 Generated with [Claude Code](https://claude.com/claude-code)