### PR TITLE
fix: enable vendor-split and stub radar_data.json

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -47,7 +47,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python etl.py --nvd-cache .nvd_cache
+          python etl.py --nvd-cache .nvd_cache --vendor-split
 
       - name: Update README metrics
         run: |
@@ -56,7 +56,7 @@ jobs:
       - name: Commit updated data
         run: |
           set -e
-          if [ -z "$(git status --porcelain data/radar_data.json data/radar_report.md README.md)" ]; then
+          if [ -z "$(git status --porcelain data/)" ]; then
             echo "No changes to radar outputs"
             exit 0
           fi
@@ -64,7 +64,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git add data/radar_data.json data/radar_report.md README.md
+          git add data/radar_data.json data/radar_report.md data/radar_index.json data/vendors/ README.md
           git commit -m "chore: update radar outputs [skip ci]"
           git pull --rebase
           git push

--- a/vulnradar/cli.py
+++ b/vulnradar/cli.py
@@ -274,12 +274,15 @@ def main_etl(argv: Sequence[str] | None = None) -> int:
 
     items = items or []
     out_path = Path(args.out)
-    write_radar_data(out_path, items)
 
     if args.vendor_split:
         index = write_vendor_split(out_path.parent, items)
         n_vendors = index["vendor_count"]
         print(f"Wrote vendor split: {n_vendors} files under {out_path.parent / 'vendors/'}")
+        # Write a slim stub so radar_data.json stays small
+        write_radar_data(out_path, [], stub_message="Data split into per-vendor files. See radar_index.json.")
+    else:
+        write_radar_data(out_path, items)
 
     state_path = Path(args.state) if args.state else None
     write_markdown_report(Path(args.report), items, state_file=state_path)

--- a/vulnradar/enrichment.py
+++ b/vulnradar/enrichment.py
@@ -303,19 +303,30 @@ def build_radar_data(
     return items
 
 
-def write_radar_data(path: Path, items: list[dict[str, Any]]) -> None:
+def write_radar_data(
+    path: Path,
+    items: list[dict[str, Any]],
+    *,
+    stub_message: str | None = None,
+) -> None:
     """Write radar data to a JSON file atomically.
 
     Args:
         path: Output file path.
         items: List of radar item dicts.
+        stub_message: If set, write a slim stub instead of the full
+            dataset (used when data is split into per-vendor files).
     """
     path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {
+    payload: dict[str, Any] = {
         "generated_at": now_utc_iso(),
         "count": len(items),
-        "items": items,
     }
+    if stub_message:
+        payload["note"] = stub_message
+        payload["items"] = []
+    else:
+        payload["items"] = items
     tmp = path.with_suffix(path.suffix + ".tmp")
     with tmp.open("w", encoding="utf-8") as f:
         json.dump(payload, f, indent=2, sort_keys=False)


### PR DESCRIPTION
## Summary
- `--vendor-split` was implemented but not used in CI, so `radar_data.json` always got the full 44MB+ monolithic dump
- Now the workflow passes `--vendor-split` so data goes into per-vendor files under `data/vendors/`
- When vendor-split is active, `radar_data.json` becomes a slim stub (just `count` + `note`), keeping it tiny
- Workflow commit step updated to include `data/vendors/` and `data/radar_index.json`

## Test plan
- [x] All 331 tests pass
- [ ] After merge + demo reset, verify `radar_data.json` is a stub and `data/vendors/*.json` has the real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)