### PR TITLE
chore: align ruff-pre-commit with ruff>=0.15.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,11 +6,11 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
-        args: ['--maxkb=500']
+        args: ["--maxkb=500"]
       - id: check-merge-conflict
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.0
+    rev: v0.15.12
     hooks:
       - id: ruff
         args: [--fix]

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -355,14 +355,16 @@ def _make_items(*vendors: str) -> list[dict[str, Any]]:
     """Create minimal radar items with matched_terms for given vendors."""
     items = []
     for i, v in enumerate(vendors):
-        items.append({
-            "cve_id": f"CVE-2024-{10000 + i}",
-            "matched_terms": [f"vendor:{v}"],
-            "is_critical": True,
-            "active_threat": False,
-            "in_watchlist": True,
-            "in_patchthis": False,
-        })
+        items.append(
+            {
+                "cve_id": f"CVE-2024-{10000 + i}",
+                "matched_terms": [f"vendor:{v}"],
+                "is_critical": True,
+                "active_threat": False,
+                "in_watchlist": True,
+                "in_patchthis": False,
+            }
+        )
     return items
 
 
@@ -409,12 +411,14 @@ class TestWriteVendorSplit:
         assert not (tmp_path / "vendors" / "microsoft.json").exists()
 
     def test_kev_only_items(self, tmp_path: Path):
-        items = [{
-            "cve_id": "CVE-2024-99999",
-            "matched_terms": [],
-            "active_threat": True,
-            "in_watchlist": False,
-        }]
+        items = [
+            {
+                "cve_id": "CVE-2024-99999",
+                "matched_terms": [],
+                "active_threat": True,
+                "in_watchlist": False,
+            }
+        ]
         index = write_vendor_split(tmp_path, items, small_vendor_threshold=1)
         assert (tmp_path / "vendors" / "_other.json").exists()
         assert index["total_count"] == 1

--- a/vulnradar/cli.py
+++ b/vulnradar/cli.py
@@ -183,7 +183,8 @@ def main_etl(argv: Sequence[str] | None = None) -> int:
     # Search command
     parser.add_argument("--search", default=None, metavar="QUERY", help="Fuzzy search vendors/products")
     parser.add_argument(
-        "--vendor-split", action="store_true",
+        "--vendor-split",
+        action="store_true",
         help="Also write per-vendor JSON files under data/vendors/",
     )
     args = parser.parse_args(argv)


### PR DESCRIPTION
## Summary
- Bumps `ruff-pre-commit` rev from `v0.8.0` to `v0.15.12` to match the ruff dev-dep floor merged in #16.
- Applies the formatter's reflow to `tests/test_enrichment.py` and `vulnradar/cli.py` so pre-commit and CI stay in sync.

## Why
After #16, `pyproject.toml` required `ruff>=0.15.12` but the pre-commit hook was still pinned at `v0.8.0`. Local runs and pre-commit disagreed on formatting rules; this realigns them.

## Test plan
- [x] `ruff check .` → all checks passed
- [x] `ruff format --check .` → 0 files would be reformatted
- [ ] CI (`test (3.11)`, `test (3.12)`, `lint`) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)